### PR TITLE
schema: 마크 검색 지원을 위한 표기코드 컬럼 추가

### DIFF
--- a/src/@types/drug_recognition.ts
+++ b/src/@types/drug_recognition.ts
@@ -18,4 +18,6 @@ export interface IDrugRecognition {
     CLASS_NAME: string; // 분류명
     ETC_OTC_CODE: string; // 전문일반구분
     ITEM_PERMIT_DATE: string; // 품목허가일자
+    MARK_CODE_FRONT: string; // 표기코드앞
+    MARK_CODE_BACK: string; // 표기코드뒤
   }

--- a/src/schemas/pill_data.ts
+++ b/src/schemas/pill_data.ts
@@ -34,6 +34,8 @@ export const PillDataSchema: ObjectSchema = {
     PACK_UNIT: { type: "string", optional: true }, // 포장단위
     MAIN_ITEM_INGR: { type: "string", optional: true }, // 주성분명
     INGR_NAME: { type: "string", optional: true }, // 첨가제명
+    MARK_CODE_FRONT: { type: "string", optional: true }, // 표기코드앞
+    MARK_CODE_BACK: { type: "string", optional: true }, // 표기코드뒤
     // Custom
     VECTOR: { type: "list", objectType: 'int', optional: true }, // 정렬벡터값
     DELETED: { type: "bool", optional: true }, // 삭제여부

--- a/src/utils/resource.ts
+++ b/src/utils/resource.ts
@@ -36,6 +36,8 @@ export const DRUG_RECOGNITION_PROPERTY_MAP = {
   분류명: "CLASS_NAME",
   전문일반구분: "ETC_OTC_CODE",
   품목허가일자: "ITEM_PERMIT_DATE",
+  표기코드앞: "MARK_CODE_FRONT",
+  표기코드뒤: "MARK_CODE_BACK",
 } as const;
 
 export const FINISHED_MEDICINE_PERMISSION_PROPERTY_MAP = {


### PR DESCRIPTION
#### 1. 관련 이슈
- #7 

#### 2. AS-IS
- 데이터베이스 스키마에 마크 검색을 위한 표기코드 컬럼이 존재하지 않는다

#### 3. TO-BE
- 표기코드 컬럼을 통해 식별 검색에서 마크 검색이 가능하다

#### 4. 작업내역 (개발적인 내용)
- 마크 검색 지원을 위한 표기코드 컬럼 추가

#### 5. 비고
- [연관 이슈](https://github.com/KNUT-Capstone-Design-team-1/wip-application-v2/issues/65)
